### PR TITLE
fix(init): propagate git.branch to init (GIT_BRANCH) so non-main repos work

### DIFF
--- a/charts/silverbullet/Chart.yaml
+++ b/charts/silverbullet/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/silverbullet/templates/secret.yaml
+++ b/charts/silverbullet/templates/secret.yaml
@@ -25,6 +25,9 @@ data:
 {{- if .Values.git.repository }}
   GIT_REPOSITORY: {{ .Values.git.repository | b64enc }}
 {{- end -}}
+{{- if .Values.git.branch }}
+  GIT_BRANCH: {{ .Values.git.branch | b64enc }}
+{{- end -}}
 {{- if .Values.init.repository }}
   INIT_REPOSITORY: {{ .Values.init.repository | b64enc }}
 {{ end -}}


### PR DESCRIPTION
The init container entrypoint refer to ${GIT_BRANCH:=main} but GIT_BRANCH is never set.
This change ensures .Values.git.branch is propagated to the Secret, allowing repositories using master or custom branch names.